### PR TITLE
Fix for Issue #5: Memory leak in captured program

### DIFF
--- a/Capture/Interface/Screenshot.cs
+++ b/Capture/Interface/Screenshot.cs
@@ -7,9 +7,9 @@ using System.IO;
 
 namespace Capture.Interface
 {
-    public class Screenshot : MarshalByRefObject
+    public class Screenshot
     {
-        public Screenshot(Guid requestId, byte[] capturedBitmap)
+        public Screenshot(Guid requestId, byte[][] capturedBitmap)
         {
             _requestId = requestId;
             _capturedBitmap = capturedBitmap;
@@ -24,8 +24,8 @@ namespace Capture.Interface
             }
         }
 
-        byte[] _capturedBitmap;
-        public byte[] CapturedBitmap
+        byte[][] _capturedBitmap;
+        public byte[][] CapturedBitmap
         {
             get
             {
@@ -36,10 +36,15 @@ namespace Capture.Interface
 
     public static class BitmapExtension
     {
-        public static Bitmap ToBitmap(this byte[] imageBytes)
+        public static Bitmap ToBitmap(this byte[][] imageBytes)
         {
-            using (MemoryStream ms = new MemoryStream(imageBytes))
+            using (MemoryStream ms = new MemoryStream())
             {
+                foreach (var imageByte in imageBytes)
+                {
+                    ms.Write(imageByte, 0, imageByte.Length);
+                }
+
                 try
                 {
                     Bitmap image = (Bitmap)Image.FromStream(ms);

--- a/Capture/Interface/ScreenshotReceivedEventArgs.cs
+++ b/Capture/Interface/ScreenshotReceivedEventArgs.cs
@@ -9,12 +9,15 @@ namespace Capture.Interface
     public class ScreenshotReceivedEventArgs: MarshalByRefObject
     {
         public Int32 ProcessId { get; set; }
-        public Screenshot Screenshot { get; set; }
+        public byte[][] Screenshot { get; set; }
 
-        public ScreenshotReceivedEventArgs(Int32 processId, Screenshot screenshot)
+        public Guid RequestId { get; set; }
+
+        public ScreenshotReceivedEventArgs(Int32 processId, byte[][] screenshot, Guid requestId)
         {
             ProcessId = processId;
             Screenshot = screenshot;
+            RequestId = requestId;
         }
     }
 }


### PR DESCRIPTION
Changed return value of BaseDXHooks.ReadFullStream to IEnumerable< byte[] >
Removed MarshalByRefObj base from Screenshot
Changed parameters of CaptureInterface.SendScreenshotResponse to (Guid, byte[][])
