### PR TITLE
Revised version of DXHookD3D9

### DIFF
--- a/Capture/Capture.csproj
+++ b/Capture/Capture.csproj
@@ -92,7 +92,9 @@
     <Compile Include="Hook\DX11\DXFont.cs" />
     <Compile Include="Hook\DX11\DXSprite.cs" />
     <Compile Include="Hook\FramesPerSecond.cs" />
+    <Compile Include="Hook\HookData.cs" />
     <Compile Include="Hook\HookManager.cs" />
+    <Compile Include="Hook\RetrieveImageDataParams.cs" />
     <Compile Include="Hook\TextDisplay.cs" />
     <Compile Include="Interface\CaptureConfig.cs" />
     <Compile Include="EntryPoint.cs" />
@@ -105,8 +107,11 @@
     <Compile Include="Hook\DXHookD3D9.cs" />
     <Compile Include="Hook\IDXHook.cs" />
     <Compile Include="Interface\CaptureInterface.cs" />
+    <Compile Include="Interface\ClientCaptureInterfaceEventProxy.cs" />
+    <Compile Include="Interface\Direct3DVersion.cs" />
     <Compile Include="Interface\DisplayTextEventArgs.cs" />
     <Compile Include="Interface\MessageReceivedEventArgs.cs" />
+    <Compile Include="Interface\MessageType.cs" />
     <Compile Include="Interface\Screenshot.cs" />
     <Compile Include="Interface\ScreenshotReceivedEventArgs.cs" />
     <Compile Include="Interface\ScreenshotRequestedEventArgs.cs" />

--- a/Capture/Hook/DXHookD3D9.cs
+++ b/Capture/Hook/DXHookD3D9.cs
@@ -1,179 +1,104 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-//using SlimDX.Direct3D9;
-using EasyHook;
 using System.Runtime.InteropServices;
-using System.IO;
 using System.Threading;
-using System.Drawing;
+
 using Capture.Interface;
+
 using SharpDX.Direct3D9;
 
 namespace Capture.Hook
 {
-    internal class DXHookD3D9: BaseDXHook
+    using SharpDX;
+
+    internal class DXHookD3D9 : BaseDXHook
     {
+        #region Constants
+
+        private const int D3D9Ex_DEVICE_METHOD_COUNT = 15;
+
+        private const int D3D9_DEVICE_METHOD_COUNT = 119;
+
+        #endregion
+
+        #region Fields
+
+        private readonly object endSceneLock = new object();
+
+        private readonly object renderTargetLock = new object();
+
+        private readonly object surfaceLock = new object();
+
+        private HookData<Direct3D9DeviceEx_PresentExDelegate> Direct3DDeviceEx_PresentExHook = null;
+
+        private HookData<Direct3D9DeviceEx_ResetExDelegate> Direct3DDeviceEx_ResetExHook = null;
+
+        private HookData<Direct3D9Device_EndSceneDelegate> Direct3DDevice_EndSceneHook = null;
+
+        private HookData<Direct3D9Device_PresentDelegate> Direct3DDevice_PresentHook = null;
+
+        private HookData<Direct3D9Device_ResetDelegate> Direct3DDevice_ResetHook = null;
+
+        private IntPtr currentDevice;
+
+        private int endSceneHookRecurse;
+
+        private Format format;
+
+        private int height;
+
+        private bool hooksStarted;
+
+        private List<IntPtr> id3dDeviceFunctionAddresses = new List<IntPtr>();
+
+        private bool isUsingPresent;
+
+        private int pitch;
+
+        private int presentHookRecurse = 0;
+
+        private Query query;
+
+        private bool queryIssued;
+
+        private Surface renderTarget;
+
+        private bool supportsDirect3DEx = false;
+
+        private Surface surface;
+
+        private IntPtr surfaceDataPointer;
+
+        private bool surfaceLocked;
+
+        private bool surfacesSetup;
+
+        private int width;
+
+        #endregion
+
+        #region Constructors and Destructors
+
         public DXHookD3D9(CaptureInterface ssInterface)
             : base(ssInterface)
         {
         }
 
-        LocalHook Direct3DDevice_EndSceneHook = null;
-        LocalHook Direct3DDevice_ResetHook = null;
-        LocalHook Direct3DDevice_PresentHook = null;
-        LocalHook Direct3DDeviceEx_PresentExHook = null;
-        object _lockRenderTarget = new object();
-        Surface _renderTarget;
+        #endregion
 
-        protected override string HookName
-        {
-            get
-            {
-                return "DXHookD3D9";
-            }
-        }
-        List<IntPtr> id3dDeviceFunctionAddresses = new List<IntPtr>();
-        //List<IntPtr> id3dDeviceExFunctionAddresses = new List<IntPtr>();
-        const int D3D9_DEVICE_METHOD_COUNT = 119;
-        const int D3D9Ex_DEVICE_METHOD_COUNT = 15;
-        bool _supportsDirect3D9Ex = false;
-        public override void Hook()
-        {
-            this.DebugMessage("Hook: Begin");
-            // First we need to determine the function address for IDirect3DDevice9
-            Device device;
-            id3dDeviceFunctionAddresses = new List<IntPtr>();
-            //id3dDeviceExFunctionAddresses = new List<IntPtr>();
-            this.DebugMessage("Hook: Before device creation");
-            using (Direct3D d3d = new Direct3D())
-            {
-                using (var renderForm = new System.Windows.Forms.Form())
-                {
-                    using (device = new Device(d3d, 0, DeviceType.NullReference, IntPtr.Zero, CreateFlags.HardwareVertexProcessing, new PresentParameters() { BackBufferWidth = 1, BackBufferHeight = 1, DeviceWindowHandle = renderForm.Handle }))
-                    {
-                        this.DebugMessage("Hook: Device created");
-                        id3dDeviceFunctionAddresses.AddRange(GetVTblAddresses(device.NativePointer, D3D9_DEVICE_METHOD_COUNT));
-                    }
-                }
-            }
+        #region Delegates
 
-            try
-            {
-                using (Direct3DEx d3dEx = new Direct3DEx())
-                {
-                    this.DebugMessage("Hook: Direct3DEx...");
-                    using (var renderForm = new System.Windows.Forms.Form())
-                    {
-                        using (var deviceEx = new DeviceEx(d3dEx, 0, DeviceType.NullReference, IntPtr.Zero, CreateFlags.HardwareVertexProcessing, new PresentParameters() { BackBufferWidth = 1, BackBufferHeight = 1, DeviceWindowHandle = renderForm.Handle }, new DisplayModeEx() { Width = 800, Height = 600 }))
-                        {
-                            this.DebugMessage("Hook: DeviceEx created - PresentEx supported");
-                            id3dDeviceFunctionAddresses.AddRange(GetVTblAddresses(deviceEx.NativePointer, D3D9_DEVICE_METHOD_COUNT, D3D9Ex_DEVICE_METHOD_COUNT));
-                            _supportsDirect3D9Ex = true;
-                        }
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                _supportsDirect3D9Ex = false;
-            }
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        private unsafe delegate int Direct3D9DeviceEx_PresentExDelegate(
+            IntPtr devicePtr, 
+            Rectangle* pSourceRect, 
+            Rectangle* pDestRect, 
+            IntPtr hDestWindowOverride, 
+            IntPtr pDirtyRegion, 
+            Present dwFlags);
 
-            // We want to hook each method of the IDirect3DDevice9 interface that we are interested in
-
-            // 42 - EndScene (we will retrieve the back buffer here)
-            Direct3DDevice_EndSceneHook = LocalHook.Create(
-                id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.EndScene],
-                // On Windows 7 64-bit w/ 32-bit app and d3d9 dll version 6.1.7600.16385, the address is equiv to:
-                // (IntPtr)(GetModuleHandle("d3d9").ToInt32() + 0x1ce09),
-                // A 64-bit app would use 0xff18
-                // Note: GetD3D9DeviceFunctionAddress will output these addresses to a log file
-                new Direct3D9Device_EndSceneDelegate(EndSceneHook),
-                this);
-
-            unsafe
-            {
-                // If Direct3D9Ex is available - hook the PresentEx
-                if (_supportsDirect3D9Ex)
-                {
-                    Direct3DDeviceEx_PresentExHook = LocalHook.Create(
-                        id3dDeviceFunctionAddresses[(int)Direct3DDevice9ExFunctionOrdinals.PresentEx],
-                        new Direct3D9DeviceEx_PresentExDelegate(PresentExHook),
-                        this);
-                }
-
-                // Always hook Present also (device will only call Present or PresentEx not both)
-                Direct3DDevice_PresentHook = LocalHook.Create(
-                    id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.Present],
-                    new Direct3D9Device_PresentDelegate(PresentHook),
-                    this);
-            }
-
-            // 16 - Reset (called on resolution change or windowed/fullscreen change - we will reset some things as well)
-            Direct3DDevice_ResetHook = LocalHook.Create(
-                id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.Reset],
-                // On Windows 7 64-bit w/ 32-bit app and d3d9 dll version 6.1.7600.16385, the address is equiv to:
-                //(IntPtr)(GetModuleHandle("d3d9").ToInt32() + 0x58dda),
-                // A 64-bit app would use 0x3b3a0
-                // Note: GetD3D9DeviceFunctionAddress will output these addresses to a log file
-                new Direct3D9Device_ResetDelegate(ResetHook),
-                this);
-
-            /*
-             * Don't forget that all hooks will start deactivated...
-             * The following ensures that all threads are intercepted:
-             * Note: you must do this for each hook.
-             */
-            Direct3DDevice_EndSceneHook.ThreadACL.SetExclusiveACL(new Int32[1]);
-            Hooks.Add(Direct3DDevice_EndSceneHook);
-
-            Direct3DDevice_PresentHook.ThreadACL.SetExclusiveACL(new Int32[1]);
-            Hooks.Add(Direct3DDevice_PresentHook);
-
-            if (_supportsDirect3D9Ex)
-            {
-                Direct3DDeviceEx_PresentExHook.ThreadACL.SetExclusiveACL(new Int32[1]);
-                Hooks.Add(Direct3DDeviceEx_PresentExHook);
-            }
-
-            Direct3DDevice_ResetHook.ThreadACL.SetExclusiveACL(new Int32[1]);
-            Hooks.Add(Direct3DDevice_ResetHook);
-
-            this.DebugMessage("Hook: End");
-        }
-
-        /// <summary>
-        /// Just ensures that the surface we created is cleaned up.
-        /// </summary>
-        public override void Cleanup()
-        {
-
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (true)
-            {
-                try
-                {
-                    lock (_lockRenderTarget)
-                    {
-                        if (_renderTarget != null)
-                        {
-                            _renderTarget.Dispose();
-                            _renderTarget = null;
-                        }
-
-                        Request = null;
-                    }
-                }
-                catch
-                {
-                }
-            }
-            base.Dispose(disposing);
-        }
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        private delegate int Direct3D9DeviceEx_ResetExDelegate(IntPtr devicePtr, ref PresentParameters presentParameters, DisplayModeEx displayModeEx);
 
         /// <summary>
         /// The IDirect3DDevice9.EndScene function definition
@@ -181,7 +106,15 @@ namespace Capture.Hook
         /// <param name="device"></param>
         /// <returns></returns>
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
-        delegate int Direct3D9Device_EndSceneDelegate(IntPtr device);
+        private delegate int Direct3D9Device_EndSceneDelegate(IntPtr device);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
+        private unsafe delegate int Direct3D9Device_PresentDelegate(
+            IntPtr devicePtr, 
+            Rectangle* pSourceRect, 
+            Rectangle* pDestRect, 
+            IntPtr hDestWindowOverride, 
+            IntPtr pDirtyRegion);
 
         /// <summary>
         /// The IDirect3DDevice9.Reset function definition
@@ -190,101 +123,225 @@ namespace Capture.Hook
         /// <param name="presentParameters"></param>
         /// <returns></returns>
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
-        delegate int Direct3D9Device_ResetDelegate(IntPtr device, ref PresentParameters presentParameters);
+        private delegate int Direct3D9Device_ResetDelegate(IntPtr device, ref PresentParameters presentParameters);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
-        unsafe delegate int Direct3D9Device_PresentDelegate(IntPtr devicePtr, SharpDX.Rectangle* pSourceRect, SharpDX.Rectangle* pDestRect, IntPtr hDestWindowOverride, IntPtr pDirtyRegion);
+        #endregion
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode, SetLastError = true)]
-        unsafe delegate int Direct3D9DeviceEx_PresentExDelegate(IntPtr devicePtr, SharpDX.Rectangle* pSourceRect, SharpDX.Rectangle* pDestRect, IntPtr hDestWindowOverride, IntPtr pDirtyRegion, Present dwFlags);
-        
+        #region Properties
 
-        /// <summary>
-        /// Reset the _renderTarget so that we are sure it will have the correct presentation parameters (required to support working across changes to windowed/fullscreen or resolution changes)
-        /// </summary>
-        /// <param name="devicePtr"></param>
-        /// <param name="presentParameters"></param>
-        /// <returns></returns>
-        int ResetHook(IntPtr devicePtr, ref PresentParameters presentParameters)
+        protected override string HookName
         {
-            Device device = (Device)devicePtr;
+            get
+            {
+                return "DXHookD3D9";
+            }
+        }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public override void Cleanup()
+        {
+            // ClearData();
+        }
+
+        public override unsafe void Hook()
+        {
+            this.DebugMessage("Hook: Begin");
+
+            this.DebugMessage("Hook: Before device creation");
+            using (var d3d = new Direct3D())
+            {
+                this.DebugMessage("Hook: Direct3D created");
+                using (
+                    var device = new Device(
+                        d3d, 
+                        0, 
+                        DeviceType.NullReference, 
+                        IntPtr.Zero, 
+                        CreateFlags.HardwareVertexProcessing, 
+                        new PresentParameters() { BackBufferWidth = 1, BackBufferHeight = 1 }))
+                {
+                    this.id3dDeviceFunctionAddresses.AddRange(this.GetVTblAddresses(device.NativePointer, D3D9_DEVICE_METHOD_COUNT));
+                }
+            }
+
             try
             {
-
-                lock (_lockRenderTarget)
+                using (var d3dEx = new Direct3DEx())
                 {
-                    if (_renderTarget != null)
+                    this.DebugMessage("Hook: Try Direct3DEx...");
+                    using (
+                        var deviceEx = new DeviceEx(
+                            d3dEx, 
+                            0, 
+                            DeviceType.NullReference, 
+                            IntPtr.Zero, 
+                            CreateFlags.HardwareVertexProcessing, 
+                            new PresentParameters() { BackBufferWidth = 1, BackBufferHeight = 1 }, 
+                            new DisplayModeEx() { Width = 800, Height = 600 }))
                     {
-                        _renderTarget.Dispose();
-                        _renderTarget = null;
+                        this.id3dDeviceFunctionAddresses.AddRange(
+                            this.GetVTblAddresses(deviceEx.NativePointer, D3D9_DEVICE_METHOD_COUNT, D3D9Ex_DEVICE_METHOD_COUNT));
+                        this.supportsDirect3DEx = true;
                     }
                 }
-                // EasyHook has already repatched the original Reset so calling it here will not cause an endless recursion to this function
-                device.Reset(presentParameters);
-                return SharpDX.Result.Ok.Code;
             }
-            catch (SharpDX.SharpDXException sde)
+            catch (Exception)
             {
-                return sde.ResultCode.Code;
+                throw;
+            }
+
+            DebugMessage("Setting up Direct3D hooks...");
+            this.Direct3DDevice_EndSceneHook =
+                new HookData<Direct3D9Device_EndSceneDelegate>(
+                    this.id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.EndScene], 
+                    new Direct3D9Device_EndSceneDelegate(this.EndSceneHook), 
+                    this);
+
+            this.Direct3DDevice_EndSceneHook.ReHook();
+            this.Hooks.Add(this.Direct3DDevice_EndSceneHook.Hook);
+
+            this.Direct3DDevice_PresentHook =
+                new HookData<Direct3D9Device_PresentDelegate>(
+                    this.id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.Present], 
+                    new Direct3D9Device_PresentDelegate(this.PresentHook), 
+                    this);
+
+            this.Direct3DDevice_ResetHook =
+                new HookData<Direct3D9Device_ResetDelegate>(
+                    this.id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.Reset], 
+                    new Direct3D9Device_ResetDelegate(this.ResetHook), 
+                    this);
+
+            if (this.supportsDirect3DEx)
+            {
+                DebugMessage("Setting up Direct3DEx hooks...");
+                this.Direct3DDeviceEx_PresentExHook =
+                    new HookData<Direct3D9DeviceEx_PresentExDelegate>(
+                        this.id3dDeviceFunctionAddresses[(int)Direct3DDevice9ExFunctionOrdinals.PresentEx], 
+                        new Direct3D9DeviceEx_PresentExDelegate(this.PresentExHook), 
+                        this);
+
+                this.Direct3DDeviceEx_ResetExHook =
+                    new HookData<Direct3D9DeviceEx_ResetExDelegate>(
+                        this.id3dDeviceFunctionAddresses[(int)Direct3DDevice9ExFunctionOrdinals.ResetEx], 
+                        new Direct3D9DeviceEx_ResetExDelegate(this.ResetExHook), 
+                        this);
+            }
+
+            this.Direct3DDevice_ResetHook.ReHook();
+            this.Hooks.Add(this.Direct3DDevice_ResetHook.Hook);
+
+            this.Direct3DDevice_PresentHook.ReHook();
+            this.Hooks.Add(this.Direct3DDevice_PresentHook.Hook);
+
+            if (this.supportsDirect3DEx)
+            {
+                this.Direct3DDeviceEx_PresentExHook.ReHook();
+                this.Hooks.Add(this.Direct3DDeviceEx_PresentExHook.Hook);
+
+                this.Direct3DDeviceEx_ResetExHook.ReHook();
+                this.Hooks.Add(this.Direct3DDeviceEx_ResetExHook.Hook);
+            }
+
+            this.DebugMessage("Hook: End");
+        }
+
+        #endregion
+
+        #region Methods
+
+        protected override void Dispose(bool disposing)
+        {
+            if (true)
+            {
+                try
+                {
+                    ClearData();
+                }
+                catch
+                {
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        private void ClearData()
+        {
+            DebugMessage("ClearData called");
+
+            // currentDevice = null;
+            this.Request = null;
+            width = 0;
+            height = 0;
+            pitch = 0;
+            surfacesSetup = false;
+            this.hooksStarted = false;
+            if (surfaceLocked)
+            {
+                lock (surfaceLock)
+                {
+                    surface.UnlockRectangle();
+                    surfaceLocked = false;
+                }
+            }
+
+            if (surface != null)
+            {
+                surface.Dispose();
+                surface = null;
+            }
+            if (renderTarget != null)
+            {
+                renderTarget.Dispose();
+                renderTarget = null;
+            }
+            if (query != null)
+            {
+                query.Dispose();
+                query = null;
+                queryIssued = false;
+            }
+        }
+
+        /// <summary>
+        /// Implementation of capturing from the render target of the Direct3D9 Device (or DeviceEx)
+        /// </summary>
+        /// <param name="device"></param>
+        private void DoCaptureRenderTarget(Device device, string hook)
+        {
+            // this.Frame();
+
+            try
+            {
+                if (!surfacesSetup)
+                {
+                    using (Surface backbuffer = device.GetRenderTarget(0))
+                    {
+                        format = backbuffer.Description.Format;
+                        width = backbuffer.Description.Width;
+                        height = backbuffer.Description.Height;
+                    }
+
+                    SetupSurfaces(device);
+                }
+
+                if (!surfacesSetup)
+                {
+                    return;
+                }
+
+                if (Request != null)
+                {
+                    HandleCaptureRequest(device);
+                }
             }
             catch (Exception e)
             {
                 DebugMessage(e.ToString());
-                return SharpDX.Result.Ok.Code;
             }
-        }
-
-        bool _isUsingPresent = false;
-
-        // Used in the overlay
-        unsafe int PresentExHook(IntPtr devicePtr, SharpDX.Rectangle* pSourceRect, SharpDX.Rectangle* pDestRect, IntPtr hDestWindowOverride, IntPtr pDirtyRegion, Present dwFlags)
-        {
-            _isUsingPresent = true;
-            DeviceEx device = (DeviceEx)devicePtr;
-
-            DoCaptureRenderTarget(device, "PresentEx");
-
-            //    Region region = new Region(pDirtyRegion);
-            if (pSourceRect == null || *pSourceRect == SharpDX.Rectangle.Empty)
-                device.PresentEx(dwFlags);
-            else
-            {
-                if (hDestWindowOverride != IntPtr.Zero)
-                    device.PresentEx(dwFlags, *pSourceRect, *pDestRect, hDestWindowOverride);
-                else
-                    device.PresentEx(dwFlags, *pSourceRect, *pDestRect);
-            }
-            return SharpDX.Result.Ok.Code;
-        }
-        
-        unsafe int PresentHook(IntPtr devicePtr, SharpDX.Rectangle* pSourceRect, SharpDX.Rectangle* pDestRect, IntPtr hDestWindowOverride, IntPtr pDirtyRegion)
-        {
-            // Example of using delegate to original function pointer to call original method
-            //var original = (Direct3D9Device_PresentDelegate)(Object)Marshal.GetDelegateForFunctionPointer(id3dDeviceFunctionAddresses[(int)Direct3DDevice9FunctionOrdinals.Present], typeof(Direct3D9Device_PresentDelegate));
-            //try
-            //{
-            //    unsafe
-            //    {
-            //        return original(devicePtr, ref pSourceRect, ref pDestRect, hDestWindowOverride, pDirtyRegion);
-            //    }
-            //}
-            //catch { }
-            _isUsingPresent = true;
-
-            Device device = (Device)devicePtr;
-
-            DoCaptureRenderTarget(device, "PresentHook");
-
-            if (pSourceRect == null || *pSourceRect == SharpDX.Rectangle.Empty)
-                device.Present();
-            else
-            {
-                if (hDestWindowOverride != IntPtr.Zero)
-                    device.Present(*pSourceRect, *pDestRect, hDestWindowOverride);
-                else
-                    device.Present(*pSourceRect, *pDestRect);
-            }
-            return SharpDX.Result.Ok.Code;
         }
 
         /// <summary>
@@ -293,120 +350,77 @@ namespace Capture.Hook
         /// <param name="devicePtr">Pointer to the IDirect3DDevice9 instance. Note: object member functions always pass "this" as the first parameter.</param>
         /// <returns>The HRESULT of the original EndScene</returns>
         /// <remarks>Remember that this is called many times a second by the Direct3D application - be mindful of memory and performance!</remarks>
-        int EndSceneHook(IntPtr devicePtr)
+        private int EndSceneHook(IntPtr devicePtr)
         {
-            Device device = (Device)devicePtr;
-
-            if (!_isUsingPresent)
-                DoCaptureRenderTarget(device, "EndSceneHook");
-
-            device.EndScene();
-            return SharpDX.Result.Ok.Code;
-        }
-        /// <summary>
-        /// Implementation of capturing from the render target of the Direct3D9 Device (or DeviceEx)
-        /// </summary>
-        /// <param name="device"></param>
-        void DoCaptureRenderTarget(Device device, string hook)
-        {
-            this.Frame();
-
+            int hresult = Result.Ok.Code;
+            var device = (Device)devicePtr;
             try
             {
-                    #region Screenshot Request
-                // Single frame capture request
-                if (this.Request != null)
+                if (endSceneHookRecurse == 0)
                 {
-                    DateTime start = DateTime.Now;
-                    try
+                    if (!hooksStarted)
                     {
-
-                        using (Surface renderTargetTemp = device.GetRenderTarget(0))
-                        {
-                            int width, height;
-
-                            // TODO: If resizing the captured image is required it can be adjusted here
-                            //if (renderTargetTemp.Description.Width > 1280)
-                            //{
-                            //    width = 1280;
-                            //    height = (int)Math.Round((renderTargetTemp.Description.Height * (1280.0 / renderTargetTemp.Description.Width)));
-                            //}
-                            //else
-                            {
-                                width = renderTargetTemp.Description.Width;
-                                height = renderTargetTemp.Description.Height;
-                            }
-
-                            // First ensure we have a Surface to the render target data into
-                            if (_renderTarget == null)
-                            {
-                                // Create offscreen surface to use as copy of render target data
-                                using (SwapChain sc = device.GetSwapChain(0))
-                                {
-                                    _renderTarget = Surface.CreateOffscreenPlain(device, width, height, sc.PresentParameters.BackBufferFormat, Pool.SystemMemory);
-                                }
-                            }
-
-                            // Create our resolved surface (resizing if necessary and to resolve any multi-sampling)
-                            using (Surface resolvedSurface = Surface.CreateRenderTarget(device, width, height, renderTargetTemp.Description.Format, MultisampleType.None, 0, false))
-                            {
-                                // Resize from Render Surface to resolvedSurface
-                                device.StretchRectangle(renderTargetTemp, resolvedSurface, TextureFilter.None);
-
-                                // Get Render Data
-                                device.GetRenderTargetData(resolvedSurface, _renderTarget);
-                            }
-                        }
-
-                        if (Request != null)
-                            ProcessRequest();
+                        DebugMessage("EndSceneHook: hooks not started");
+                        SetupData(device);
                     }
-                    finally
-                    {
-                        // We have completed the request - mark it as null so we do not continue to try to capture the same request
-                        // Note: If you are after high frame rates, consider implementing buffers here to capture more frequently
-                        //         and send back to the host application as needed. The IPC overhead significantly slows down 
-                        //         the whole process if sending frame by frame.
-                        Request = null;
-                    }
-                    DateTime end = DateTime.Now;
-                    this.DebugMessage(hook + ": Capture time: " + (end - start).ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            endSceneHookRecurse++;
+            hresult = Direct3DDevice_EndSceneHook.Original(devicePtr);
+            endSceneHookRecurse--;
+            return hresult;
+        }
+
+        private void HandleCaptureRequest(Device device)
+        {
+            if (Request == null)
+            {
+                return;
+            }
+            try
+            {
+                bool tmp;
+                if (queryIssued && query.GetData(out tmp, false))
+                {
+                    queryIssued = false;
+                    var lockedRect = surface.LockRectangle(LockFlags.ReadOnly);
+                    surfaceDataPointer = lockedRect.DataPointer;
+                    surfaceLocked = true;
+
+                    new Thread(HandleCaptureRequestThread).Start();
                 }
 
-                #endregion
-
-                if (this.Config.ShowOverlay)
+                using (var backbuffer = device.GetBackBuffer(0, 0))
                 {
-                    #region Draw frame rate
+                    device.StretchRectangle(backbuffer, renderTarget, TextureFilter.None);
+                }
 
-                    // TODO: font needs to be created and then reused, not created each frame!
-                    using (SharpDX.Direct3D9.Font font = new SharpDX.Direct3D9.Font(device, new FontDescription()
-                                    {
-                                        Height = 16,
-                                        FaceName = "Arial",
-                                        Italic = false,
-                                        Width = 0,
-                                        MipLevels = 1,
-                                        CharacterSet = FontCharacterSet.Default,
-                                        OutputPrecision = FontPrecision.Default,
-                                        Quality = FontQuality.Antialiased,
-                                        PitchAndFamily = FontPitchAndFamily.Default | FontPitchAndFamily.DontCare,
-                                        Weight = FontWeight.Bold
-                                    }))
+                if (surfaceLocked)
+                {
+                    lock (renderTargetLock)
                     {
-
-                        if (this.FPS.GetFPS() >= 1)
+                        if (!this.surfaceLocked)
                         {
-                            font.DrawText(null, String.Format("{0:N0} fps", this.FPS.GetFPS()), 5, 5, SharpDX.Color.Red);
+                            return;
                         }
-
-                        if (this.TextDisplay != null && this.TextDisplay.Display)
-                        {
-                            font.DrawText(null, this.TextDisplay.Text, 5, 25, new SharpDX.ColorBGRA(255, 0, 0, (byte)Math.Round((Math.Abs(1.0f - TextDisplay.Remaining) * 255f))));
-                        }
+                        this.surface.UnlockRectangle();
+                        this.surfaceLocked = false;
                     }
+                }
 
-                    #endregion
+                try
+                {
+                    device.GetRenderTargetData(renderTarget, surface);
+                    query.Issue(Issue.End);
+                    queryIssued = true;
+                }
+                catch (Exception ex)
+                {
+                    DebugMessage(ex.ToString());
                 }
             }
             catch (Exception e)
@@ -414,54 +428,185 @@ namespace Capture.Hook
                 DebugMessage(e.ToString());
             }
         }
-        
-        /// <summary>
-        /// Copies the _renderTarget surface into a stream and starts a new thread to send the data back to the host process
-        /// </summary>
-        void ProcessRequest()
+
+        private void HandleCaptureRequestThread()
         {
-            if (Request != null)
+            try
             {
-                Rectangle region = Request.RegionToCapture;
-                
-                // Prepare the parameters for RetrieveImageData to be called in a separate thread.
-                RetrieveImageDataParams retrieveParams = new RetrieveImageDataParams();
-
-                // After the Stream is created we are now finished with _renderTarget and have our own separate copy of the data,
-                // therefore it will now be safe to begin a new thread to complete processing.
-                // Note: RetrieveImageData will take care of closing the stream.
-                // Note 2: Surface.ToStream is the slowest part of the screen capture process - the other methods
-                //         available to us at this point are _renderTarget.GetDC(), and _renderTarget.LockRectangle/UnlockRectangle
-                if (Request.RegionToCapture.Width == 0)
+                if (Request == null)
                 {
-                    // The width is 0 so lets grab the entire surface
-                    retrieveParams.Stream = Surface.ToStream(_renderTarget, ImageFileFormat.Bmp);
-                }
-                else if (Request.RegionToCapture.Height > 0)
-                {
-                    retrieveParams.Stream = Surface.ToStream(_renderTarget, ImageFileFormat.Bmp, new SharpDX.Rectangle(region.Left, region.Top, region.Right, region.Bottom));
+                    return;
                 }
 
-                if (retrieveParams.Stream != null)
+                lock (renderTargetLock)
                 {
-                    // _screenshotRequest will most probably be null by the time RetrieveImageData is executed 
-                    // in a new thread, therefore we must provide the RequestId separately.
-                    retrieveParams.RequestId = Request.RequestId;
-
-                    // Begin a new thread to process the image data and send the request result back to the host application
-                    Thread t = new Thread(new ParameterizedThreadStart(RetrieveImageData));
+                    var size = height * pitch;
+                    var bdata = new byte[size];
+                    Marshal.Copy(surfaceDataPointer, bdata, 0, size);
+                    var retrieveParams = new RetrieveImageDataParams()
+                                             {
+                                                 RequestId = Request.RequestId, 
+                                                 Data = bdata, 
+                                                 Width = width, 
+                                                 Height = height, 
+                                                 Pitch = pitch
+                                             };
+                    var t = new Thread(RetrieveImageData);
                     t.Start(retrieveParams);
                 }
             }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            finally
+            {
+                Request = null;
+            }
+        }
+
+        private unsafe int PresentExHook(
+            IntPtr devicePtr, 
+            Rectangle* pSourceRect, 
+            Rectangle* pDestRect, 
+            IntPtr hDestWindowOverride, 
+            IntPtr pDirtyRegion, 
+            Present dwFlags)
+        {
+            int hresult = Result.Ok.Code;
+            var device = (DeviceEx)devicePtr;
+            if (!hooksStarted)
+            {
+                hresult = Direct3DDeviceEx_PresentExHook.Original(devicePtr, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);
+                return hresult;
+            }
+
+            try
+            {
+                if (this.presentHookRecurse == 0)
+                {
+                    this.DoCaptureRenderTarget(device, "PresentEx");
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            finally
+            {
+                this.presentHookRecurse++;
+                hresult = Direct3DDeviceEx_PresentExHook.Original(devicePtr, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);
+                this.presentHookRecurse--;
+            }
+            return hresult;
+        }
+
+        private unsafe int PresentHook(
+            IntPtr devicePtr, 
+            Rectangle* pSourceRect, 
+            Rectangle* pDestRect, 
+            IntPtr hDestWindowOverride, 
+            IntPtr pDirtyRegion)
+        {
+            int hresult;
+            var device = (Device)devicePtr;
+            if (!hooksStarted)
+            {
+                hresult = Direct3DDevice_PresentHook.Original(devicePtr, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+                return hresult;
+            }
+            try
+            {
+                if (presentHookRecurse == 0)
+                {
+                    DoCaptureRenderTarget(device, "PresentHook");
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            finally
+            {
+                presentHookRecurse++;
+                hresult = Direct3DDevice_PresentHook.Original(devicePtr, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+                presentHookRecurse--;
+            }
+            return hresult;
+        }
+
+        // private bool IsDeviceReady(Device device)
+        // {
+        // var cooplevel = device.TestCooperativeLevel();
+        // if (cooplevel.Code != ResultCode.Success.Code)
+        // {
+        // return false;
+        // }
+        // return true;
+        // }
+
+        private int ResetExHook(IntPtr devicePtr, ref PresentParameters presentparameters, DisplayModeEx displayModeEx)
+        {
+            int hresult = Result.Ok.Code;
+            DeviceEx device = (DeviceEx)devicePtr;
+            try
+            {
+                if (!hooksStarted)
+                {
+                    hresult = Direct3DDeviceEx_ResetExHook.Original(devicePtr, ref presentparameters, displayModeEx);
+                    return hresult;
+                }
+
+                ClearData();
+
+                hresult = Direct3DDeviceEx_ResetExHook.Original(devicePtr, ref presentparameters, displayModeEx);
+
+                if (currentDevice != devicePtr)
+                {
+                    hooksStarted = false;
+                    currentDevice = devicePtr;
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            return hresult;
         }
 
         /// <summary>
-        /// Used to hold the parameters to be passed to RetrieveImageData
+        /// Reset the _renderTarget so that we are sure it will have the correct presentation parameters (required to support working across changes to windowed/fullscreen or resolution changes)
         /// </summary>
-        struct RetrieveImageDataParams
+        /// <param name="devicePtr"></param>
+        /// <param name="presentParameters"></param>
+        /// <returns></returns>
+        private int ResetHook(IntPtr devicePtr, ref PresentParameters presentParameters)
         {
-            internal Stream Stream;
-            internal Guid RequestId;
+            int hresult = Result.Ok.Code;
+            Device device = (Device)devicePtr;
+            try
+            {
+                if (!hooksStarted)
+                {
+                    hresult = Direct3DDevice_ResetHook.Original(devicePtr, ref presentParameters);
+                    return hresult;
+                }
+
+                ClearData();
+
+                hresult = Direct3DDevice_ResetHook.Original(devicePtr, ref presentParameters);
+
+                if (currentDevice != devicePtr)
+                {
+                    hooksStarted = false;
+                    currentDevice = devicePtr;
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugMessage(ex.ToString());
+            }
+            return hresult;
         }
 
         /// <summary>
@@ -469,17 +614,47 @@ namespace Capture.Hook
         /// </summary>
         /// <param name="param">An instance of RetrieveImageDataParams is required to be passed as the parameter.</param>
         /// <remarks>The stream object passed will be closed!</remarks>
-        void RetrieveImageData(object param)
+        private void RetrieveImageData(object param)
         {
-            RetrieveImageDataParams retrieveParams = (RetrieveImageDataParams)param;
+            var retrieveParams = (RetrieveImageDataParams)param;
+            ProcessCapture(retrieveParams);
+        }
+
+        private void SetupData(Device device)
+        {
+            DebugMessage("SetupData called");
+
+            using (SwapChain swapChain = device.GetSwapChain(0))
+            {
+                PresentParameters pp = swapChain.PresentParameters;
+                width = pp.BackBufferWidth;
+                height = pp.BackBufferHeight;
+                format = pp.BackBufferFormat;
+
+                DebugMessage(string.Format("D3D9 Setup: w: {0} h: {1} f: {2}", width, height, format));
+            }
+
+            this.hooksStarted = true;
+        }
+
+        private void SetupSurfaces(Device device)
+        {
             try
             {
-                ProcessCapture(retrieveParams.Stream, retrieveParams.RequestId);
+                this.surface = Surface.CreateOffscreenPlain(device, width, height, (Format)format, Pool.SystemMemory);
+                var lockedRect = this.surface.LockRectangle(LockFlags.ReadOnly);
+                this.pitch = lockedRect.Pitch;
+                this.surface.UnlockRectangle();
+                this.renderTarget = Surface.CreateRenderTarget(device, width, height, format, MultisampleType.None, 0, false);
+                this.query = new Query(device, QueryType.Event);
+                surfacesSetup = true;
             }
-            finally
+            catch (Exception ex)
             {
-                retrieveParams.Stream.Close();
+                DebugMessage(ex.ToString());
             }
         }
+
+        #endregion
     }
 }

--- a/Capture/Hook/HookData.cs
+++ b/Capture/Hook/HookData.cs
@@ -1,0 +1,82 @@
+﻿namespace Capture.Hook
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    using EasyHook;
+
+    public class HookData<T> : HookData
+        where T : class
+    {
+        private readonly T original;
+
+        public HookData(IntPtr func, Delegate inNewProc, object owner)
+            : base(func, inNewProc, owner)
+        {
+            original = (T)(object)Marshal.GetDelegateForFunctionPointer(func, typeof(T));
+        }
+
+        public T Original
+        {
+            get
+            {
+                return original;
+            }
+        }
+    }
+
+    public class HookData
+    {
+        private readonly IntPtr func;
+
+        private readonly Delegate inNewProc;
+
+        private readonly object owner;
+
+        private LocalHook localHook;
+
+        private bool isHooked;
+
+        public HookData(IntPtr func, Delegate inNewProc, object owner)
+        {
+            this.func = func;
+            this.inNewProc = inNewProc;
+            this.owner = owner;
+            CreateHook();
+        }
+
+        public LocalHook Hook
+        {
+            get
+            {
+                return this.localHook;
+            }
+        }
+
+        public void CreateHook()
+        {
+            if (localHook != null) return;
+            this.localHook = LocalHook.Create(func, inNewProc, owner);
+        }
+
+        public void UnHook()
+        {
+            //if (!this.isHooked) return;
+            //this.isHooked = false;
+            //this.Hook.ThreadACL.SetInclusiveACL(new Int32[] { 0 });
+
+            //if (localHook == null) return;
+            //this.isHooked = false;
+            //this.Hook.ThreadACL.SetInclusiveACL(new Int32[] { 0 });
+            //localHook.Dispose();
+            //localHook = null;
+        }
+
+        public void ReHook()
+        {
+            if (this.isHooked) return;
+            this.isHooked = true;
+            this.Hook.ThreadACL.SetExclusiveACL(new Int32[] { 0 });
+        }
+    }
+}

--- a/Capture/Hook/RetrieveImageDataParams.cs
+++ b/Capture/Hook/RetrieveImageDataParams.cs
@@ -1,0 +1,20 @@
+namespace Capture.Hook
+{
+    using System;
+
+    /// <summary>
+    /// Used to hold the parameters to be passed to RetrieveImageData
+    /// </summary>
+    public struct RetrieveImageDataParams
+    {
+        public Guid RequestId { get; set; }
+
+        public byte[] Data { get; set; }
+
+        public int Height { get; set; }
+
+        public int Width { get; set; }
+
+        public int Pitch { get; set; }
+    }
+}

--- a/Capture/Interface/CaptureInterface.cs
+++ b/Capture/Interface/CaptureInterface.cs
@@ -7,17 +7,6 @@ using System.Threading;
 
 namespace Capture.Interface
 {
-    public enum Direct3DVersion
-    {
-        Unknown,
-        AutoDetect,
-        Direct3D9,
-        Direct3D10,
-        Direct3D10_1,
-        Direct3D11,
-        Direct3D11_1,
-    }
-
     [Serializable]
     public delegate void RecordingStartedEvent(CaptureConfig config);
     [Serializable]
@@ -32,14 +21,6 @@ namespace Capture.Interface
     public delegate void ScreenshotRequestedEvent(ScreenshotRequest request);
     [Serializable]
     public delegate void DisplayTextEvent(DisplayTextEventArgs args);
-
-    public enum MessageType
-    {
-        Debug,
-        Information,
-        Warning,
-        Error
-    }
 
     [Serializable]
     public class CaptureInterface : MarshalByRefObject
@@ -214,6 +195,11 @@ namespace Capture.Interface
         /// </summary>
         public void Disconnect()
         {
+            if (IsRecording)
+            {
+                StopRecording();
+            }
+
             SafeInvokeDisconnected();
         }
 
@@ -434,84 +420,6 @@ namespace Capture.Interface
         public void Ping()
         {
             
-        }
-    }
-
-
-    /// <summary>
-    /// Client event proxy for marshalling event handlers
-    /// </summary>
-    public class ClientCaptureInterfaceEventProxy : MarshalByRefObject
-    {
-        #region Event Declarations
-
-        /// <summary>
-        /// Client event used to communicate to the client that it is time to start recording
-        /// </summary>
-        public event RecordingStartedEvent RecordingStarted;
-
-        /// <summary>
-        /// Client event used to communicate to the client that it is time to stop recording
-        /// </summary>
-        public event RecordingStoppedEvent RecordingStopped;
-
-        /// <summary>
-        /// Client event used to communicate to the client that it is time to create a screenshot
-        /// </summary>
-        public event ScreenshotRequestedEvent ScreenshotRequested;
-
-        /// <summary>
-        /// Client event used to notify the hook to exit
-        /// </summary>
-        public event DisconnectedEvent Disconnected;
-
-        /// <summary>
-        /// Client event used to display in-game text
-        /// </summary>
-        public event DisplayTextEvent DisplayText;
-
-        #endregion
-
-        #region Lifetime Services
-
-        public override object InitializeLifetimeService()
-        {
-            //Returning null holds the object alive
-            //until it is explicitly destroyed
-            return null;
-        }
-
-        #endregion
-
-        public void RecordingStartedProxyHandler(CaptureConfig config)
-        {
-            if (RecordingStarted != null)
-                RecordingStarted(config);
-        }
-
-        public void RecordingStoppedProxyHandler()
-        {
-            if (RecordingStopped != null)
-                RecordingStopped();
-        }
-
-
-        public void DisconnectedProxyHandler()
-        {
-            if (Disconnected != null)
-                Disconnected();
-        }
-
-        public void ScreenshotRequestedProxyHandler(ScreenshotRequest request)
-        {
-            if (ScreenshotRequested != null)
-                ScreenshotRequested(request);
-        }
-
-        public void DisplayTextProxyHandler(DisplayTextEventArgs args)
-        {
-            if (DisplayText != null)
-                DisplayText(args);
         }
     }
 }

--- a/Capture/Interface/ClientCaptureInterfaceEventProxy.cs
+++ b/Capture/Interface/ClientCaptureInterfaceEventProxy.cs
@@ -1,0 +1,81 @@
+﻿namespace Capture.Interface
+{
+    using System;
+
+    /// <summary>
+    /// Client event proxy for marshalling event handlers
+    /// </summary>
+    public class ClientCaptureInterfaceEventProxy : MarshalByRefObject
+    {
+        #region Event Declarations
+
+        /// <summary>
+        /// Client event used to communicate to the client that it is time to start recording
+        /// </summary>
+        public event RecordingStartedEvent RecordingStarted;
+
+        /// <summary>
+        /// Client event used to communicate to the client that it is time to stop recording
+        /// </summary>
+        public event RecordingStoppedEvent RecordingStopped;
+
+        /// <summary>
+        /// Client event used to communicate to the client that it is time to create a screenshot
+        /// </summary>
+        public event ScreenshotRequestedEvent ScreenshotRequested;
+
+        /// <summary>
+        /// Client event used to notify the hook to exit
+        /// </summary>
+        public event DisconnectedEvent Disconnected;
+
+        /// <summary>
+        /// Client event used to display in-game text
+        /// </summary>
+        public event DisplayTextEvent DisplayText;
+
+        #endregion
+
+        #region Lifetime Services
+
+        public override object InitializeLifetimeService()
+        {
+            //Returning null holds the object alive
+            //until it is explicitly destroyed
+            return null;
+        }
+
+        #endregion
+
+        public void RecordingStartedProxyHandler(CaptureConfig config)
+        {
+            if (this.RecordingStarted != null)
+                this.RecordingStarted(config);
+        }
+
+        public void RecordingStoppedProxyHandler()
+        {
+            if (this.RecordingStopped != null)
+                this.RecordingStopped();
+        }
+
+
+        public void DisconnectedProxyHandler()
+        {
+            if (this.Disconnected != null)
+                this.Disconnected();
+        }
+
+        public void ScreenshotRequestedProxyHandler(ScreenshotRequest request)
+        {
+            if (this.ScreenshotRequested != null)
+                this.ScreenshotRequested(request);
+        }
+
+        public void DisplayTextProxyHandler(DisplayTextEventArgs args)
+        {
+            if (this.DisplayText != null)
+                this.DisplayText(args);
+        }
+    }
+}

--- a/Capture/Interface/Direct3DVersion.cs
+++ b/Capture/Interface/Direct3DVersion.cs
@@ -1,0 +1,14 @@
+namespace Capture.Interface
+{
+    public enum Direct3DVersion
+    {
+        Unknown,
+        AutoDetect,
+        Direct3D9,
+        Direct3D9Obs,
+        Direct3D10,
+        Direct3D10_1,
+        Direct3D11,
+        Direct3D11_1,
+    }
+}

--- a/Capture/Interface/MessageType.cs
+++ b/Capture/Interface/MessageType.cs
@@ -1,0 +1,11 @@
+﻿namespace Capture.Interface
+{
+    public enum MessageType
+    {
+        Debug,
+        Information,
+        Warning,
+        Error,
+        Trace
+    }
+}

--- a/TestScreenshot/Form1.cs
+++ b/TestScreenshot/Form1.cs
@@ -19,6 +19,8 @@ using Capture;
 
 namespace TestScreenshot
 {
+    using System.Drawing.Imaging;
+
     public partial class Form1 : Form
     {
         public Form1()
@@ -243,7 +245,21 @@ namespace TestScreenshot
                         {
                             pictureBox1.Image.Dispose();
                         }
-                        pictureBox1.Image = screenshot.CapturedBitmap.ToBitmap();
+                        if (screenshot.Height > 0 && screenshot.Width > 0)
+                        {
+                            var width = screenshot.Width;
+                            var height = screenshot.Height;
+                            var bitmapData = screenshot.CapturedBitmap;
+                            var img = new Bitmap(width, height, PixelFormat.Format32bppRgb);
+                            var bmpData = img.LockBits(new Rectangle(0, 0, img.Width, img.Height), ImageLockMode.WriteOnly, img.PixelFormat);
+                            Marshal.Copy(bitmapData, 0, bmpData.Scan0, bitmapData.Length);
+                            img.UnlockBits(bmpData);
+                            pictureBox1.Image = img;
+                        }
+                        else
+                        {
+                            pictureBox1.Image = screenshot.CapturedBitmap.ToBitmap();                            
+                        }
                     })
                     );
                 }


### PR DESCRIPTION
- Revised version of DXHookD3D9
- Some refactoring (like extracting types in their own file)
- Added a Hookdata which 'manages' the hook. This makes the code a bit cleaner (instead of all those long method calls)

The D3D9 version does not use SharpDX ToStream() method to get the image byte data, that means that on the receiving side we also cannot use Bitmap.FromStream.
To fix this, I added Width/Height and Pitch to the screenshot class. On the client this is checked and when they are specified it uses LockBits to generate the bitmap.
This allows both the DX9 and other versions to work, (e.g. use SharpDX ToStream and don't specify width/height or use raw byte[] data and specify height/width)
