### PR TITLE
Fix PixelData capture with Direct3D11

### DIFF
--- a/Capture/Hook/DXHookD3D11.cs
+++ b/Capture/Hook/DXHookD3D11.cs
@@ -481,14 +481,14 @@ namespace Capture.Hook
                                     finally
                                     {
                                         this.DebugMessage("PresentHook: Copy to System Memory time: " + (DateTime.Now - startCopyToSystemMemory).ToString());
-                                    }
-
-                                    if (_finalRTMapped)
-                                    {
-                                        lock (_lock)
+                                        
+                                        if (_finalRTMapped)
                                         {
-                                            _finalRT.Device.ImmediateContext.UnmapSubresource(_finalRT, 0);
-                                            _finalRTMapped = false;
+                                            lock (_lock)
+                                            {
+                                                _finalRT.Device.ImmediateContext.UnmapSubresource(_finalRT, 0);
+                                                _finalRTMapped = false;
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
When taking screenshots on Direct3D11 of `ImageFormat.PixelData` only one image succeeds and rest fail.

It happens due to the subresource not being released.

I moved the code to release subresource into the `finally` blocked and it was fixed.