### PR TITLE
Fixed a memory leak in DX11 > DXSprite.cs

### DIFF
--- a/Capture/Hook/DX11/DXSprite.cs
+++ b/Capture/Hook/DX11/DXSprite.cs
@@ -278,9 +278,8 @@ technique11 SpriteTech {
 
             _batchTexSRV = texSRV;
 
-            Texture2D tex = _batchTexSRV.ResourceAs<Texture2D>();
+            using (Texture2D tex = _batchTexSRV.ResourceAs<Texture2D>())
             {
-
                 Texture2DDescription texDesc = tex.Description;
                 _texWidth = texDesc.Width;
                 _texHeight = texDesc.Height;


### PR DESCRIPTION
A Texture2D object created at BeginBatch was not being disposed properly. By wraping the Texture2D object in a using statement, this issue is now fixed!